### PR TITLE
feature: add option for external definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ restifySwaggerJsdoc.createSwaggerPage({
     server: server, // Restify server instance created with restify.createServer()
     path: '/docs/swagger', // Public url where the swagger page will be available
     apis: [ `${__dirname}/controllers/*.js` ], // Path to the API docs
+    definitions: {myObject: require('api/myObject.json')}, // External definitions to add to swagger (optional)
     routePrefix: 'prefix', // prefix to add for all routes (optional)
     forceSecure: false // force swagger-ui to use https protocol to load JSON file (optional, default: false)
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ export interface SwaggerPageOptions {
     server: Server;
     path: string;
     apis: string[];
+    definitions?: {[key: string]: any};
     routePrefix?: string;
     forceSecure?: boolean;
 }

--- a/index.js
+++ b/index.js
@@ -26,12 +26,12 @@ var createSwaggerPage = (options) => {
         },
         apis: options.apis || []
     });
-	//Add any external definitions provided
-	for (var externalDefinition in options.definitions) {
-	    if(options.definitions.hasOwnProperty(externalDefinition)) {
-			swaggerSpec.definitions[externalDefinition] = options.definitions[externalDefinition];
-		}
-	}
+    if(options.definitions) {
+        //Add any external definitions provided
+        for (var externalDefinition in options.definitions) {
+            swaggerSpec.definitions[externalDefinition] = options.definitions[externalDefinition];
+        }
+    }
 
     // Prepend route prefix if needed
     if (options.routePrefix && swaggerSpec.hasOwnProperty('paths')) {

--- a/index.js
+++ b/index.js
@@ -26,6 +26,12 @@ var createSwaggerPage = (options) => {
         },
         apis: options.apis || []
     });
+	//Add any external definitions provided
+	for (var externalDefinition in options.definitions) {
+	    if(options.definitions.hasOwnProperty(externalDefinition)) {
+			swaggerSpec.definitions[externalDefinition] = options.definitions[externalDefinition];
+		}
+	}
 
     // Prepend route prefix if needed
     if (options.routePrefix && swaggerSpec.hasOwnProperty('paths')) {


### PR DESCRIPTION
This is just a simple way to add existing JSON schema files to Swagger's definitions.

I have no idea what to do with the TypeScript definition file for this change.